### PR TITLE
refactor(router): remove ShellRoute observer workaround

### DIFF
--- a/packages/app/lib/router/src/router_provider.dart
+++ b/packages/app/lib/router/src/router_provider.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -19,41 +17,17 @@ final rootNavigatorKey = GlobalKey<NavigatorState>();
 @Riverpod(keepAlive: true)
 Raw<GoRouter> router(Ref ref) {
   final tracker = ref.watch(trackerProvider);
-  late GoRouter router;
-  router = GoRouter(
+  return GoRouter(
     navigatorKey: rootNavigatorKey,
     routes: $appRoutes,
     observers: [
-      // Used to monitor transitions that cannot be detected by routerDelegate.
       ...tracker.navigatorObservers(
         nameExtractor: (settings) {
-          final config = router.routerDelegate.currentConfiguration;
-          debugPrint('🚀nameExtractor: ${config.uri.path}/${settings.name}');
-          return '${config.uri.path}/${settings.name}';
-        },
-        routeFilter: (route) {
-          // Only monitor transitions made with Navigator.
-          // Transitions with GoRouter are detected by routerDelegate,
-          // so they are not monitored here.
-          return route is MaterialPageRoute;
+          debugPrint('🚀nameExtractor: ${settings.name}');
+          return settings.name ?? 'unknown';
         },
       ),
     ],
     initialLocation: HomeRouteData.path,
   );
-
-  // Send a screen transition event during screen transitions.
-  Future<void> handleRouteChanged() async {
-    final config = router.routerDelegate.currentConfiguration;
-    final path = config.uri.path;
-    debugPrint('🚀handleRouteChanged: $path');
-    unawaited(tracker.trackScreenView(path));
-  }
-
-  router.routerDelegate.addListener(handleRouteChanged);
-  ref.onDispose(() async {
-    router.routerDelegate.removeListener(handleRouteChanged);
-  });
-
-  return router;
 }

--- a/packages/app/lib/router/src/router_provider.g.dart
+++ b/packages/app/lib/router/src/router_provider.g.dart
@@ -54,4 +54,4 @@ final class RouterProvider
   }
 }
 
-String _$routerHash() => r'8370380049be61504dc5fd78b9fe662117cf101e';
+String _$routerHash() => r'e764e2fe56c66902f31886634f06d7d764e4beca';


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been accomplished in this Pull Request? -->

go_router 17.0.0 now notifies root observers for ShellRoute navigation by default, eliminating the need for custom listener-based tracking.

- Remove routerDelegate listener and manual handleRouteChanged
- Simplify nameExtractor to use settings.name directly
- Remove routeFilter as it's no longer needed

## ✍️ What's Not Done
<!-- What is not included in this Pull Request? If none, write "None". -->
- None

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or implementation notes. -->
- None

## 🖼️ Image Differences
<!-- Attach before and after screenshots or videos if there are UI changes. -->

| Before    | After     |
| --------- | --------- |
| __image__ | __image__ |

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)