### PR TITLE
build(deps): bump printing to 5.15.0 & flutter_local_notifications to 22.0.1

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,33 @@
+# Pull Request Guidelines
+
+## Before Writing a PR
+
+- **Check at least 5 non-dependabot PRs** to match format, language, section structure, and conventions
+- **Language**: Always English (code, PR body, commit messages)
+- **Never link to external GitHub repositories** in PR bodies, comments, or commit messages
+  - GitHub creates permanent "mentioned this pull request" cross-references that cannot be deleted
+  - Reference external repos by name/version in plain text only
+  - Never use `org/repo#123` syntax or full GitHub URLs to external repos
+  - Internal references (e.g., `#251`) are fine
+
+## Required Sections
+
+All PR bodies must include these sections:
+
+```
+## 🙌 What's Done
+## ✍️ What's Not Done
+## 📝 Additional Notes
+## 🖼️ Image Differences
+## Pre-launch Checklist
+```
+
+- **What's Not Done**: Write "None" if nothing is pending
+- **Additional Notes**: Write "None" if no notes
+- **Image Differences**: Write "None (description of change type, no UI changes)" if no UI changes
+- **Pre-launch Checklist**: Always include `- [x] I have reviewed my own code (e.g., updated tests and documentation)`
+- Do not skip sections regardless of PR size
+
+## Attribution
+
+- Never add "Generated with Claude Code" or any AI attribution to PR bodies

--- a/packages/app/ios/Podfile.lock
+++ b/packages/app/ios/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
   - Flutter (1.0.0)
-  - printing (1.0.0):
-    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - printing (from `.symlinks/plugins/printing/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  printing:
-    :path: ".symlinks/plugins/printing/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  printing: 54ff03f28fe9ba3aa93358afb80a8595a071dd07
 
 PODFILE CHECKSUM: f3a4224ef82635613da5f978ef476c8205bfb5c2
 

--- a/packages/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/app/ios/Runner.xcodeproj/project.pbxproj
@@ -217,7 +217,6 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				701FC85966ED04B70B483F55 /* [CP] Embed Pods Frameworks */,
 				9492A9B9C143123D66C56BC5 /* FlutterFire: "flutterfire upload-crashlytics-symbols" */,
 			);
 			buildRules = (
@@ -335,23 +334,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		701FC85966ED04B70B483F55 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9492A9B9C143123D66C56BC5 /* FlutterFire: "flutterfire upload-crashlytics-symbols" */ = {

--- a/packages/app/lib/gen/assets.gen.dart
+++ b/packages/app/lib/gen/assets.gen.dart
@@ -25,9 +25,7 @@ class $AssetsImagesGen {
   List<AssetGenImage> get values => [backup, restoredBackup];
 }
 
-class Assets {
-  const Assets._();
-
+abstract final class Assets {
   static const AssetGenImage adaptiveIcon = AssetGenImage(
     'assets/adaptive-icon.png',
   );

--- a/packages/core/notification_client/pubspec.yaml
+++ b/packages/core/notification_client/pubspec.yaml
@@ -12,13 +12,13 @@ dependencies:
   clock: ^1.1.2
   flutter:
     sdk: flutter
-  flutter_local_notifications: ^20.1.0
+  flutter_local_notifications: ^22.0.1
   flutter_timezone: ^5.0.2
   freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
   prefs_client:
     path: ../prefs_client
-  timezone: ^0.10.1
+  timezone: ^0.11.0
 
 dev_dependencies:
   # Temporarily disabled: analyzer constraint conflicts with the riverpod stack (analyzer 12).

--- a/packages/core/notification_client/test/utils/mock.mocks.dart
+++ b/packages/core/notification_client/test/utils/mock.mocks.dart
@@ -12,28 +12,27 @@ import 'package:flutter_local_notifications/src/initialization_settings.dart'
 import 'package:flutter_local_notifications/src/notification_details.dart'
     as _i6;
 import 'package:flutter_local_notifications/src/platform_flutter_local_notifications.dart'
-    as _i10;
+    as _i9;
 import 'package:flutter_local_notifications/src/platform_specifics/android/enums.dart'
-    as _i13;
-import 'package:flutter_local_notifications/src/platform_specifics/android/initialization_settings.dart'
-    as _i11;
-import 'package:flutter_local_notifications/src/platform_specifics/android/notification_channel.dart'
-    as _i15;
-import 'package:flutter_local_notifications/src/platform_specifics/android/notification_channel_group.dart'
-    as _i14;
-import 'package:flutter_local_notifications/src/platform_specifics/android/notification_details.dart'
     as _i12;
+import 'package:flutter_local_notifications/src/platform_specifics/android/initialization_settings.dart'
+    as _i10;
+import 'package:flutter_local_notifications/src/platform_specifics/android/notification_channel.dart'
+    as _i14;
+import 'package:flutter_local_notifications/src/platform_specifics/android/notification_channel_group.dart'
+    as _i13;
+import 'package:flutter_local_notifications/src/platform_specifics/android/notification_details.dart'
+    as _i11;
 import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
     as _i8;
 import 'package:flutter_local_notifications/src/platform_specifics/android/styles/messaging_style_information.dart'
-    as _i16;
+    as _i15;
 import 'package:flutter_local_notifications/src/platform_specifics/darwin/initialization_settings.dart'
-    as _i17;
+    as _i16;
 import 'package:flutter_local_notifications/src/platform_specifics/darwin/notification_details.dart'
-    as _i19;
-import 'package:flutter_local_notifications/src/platform_specifics/darwin/notification_enabled_options.dart'
     as _i18;
-import 'package:flutter_local_notifications/src/types.dart' as _i9;
+import 'package:flutter_local_notifications/src/platform_specifics/darwin/notification_enabled_options.dart'
+    as _i17;
 import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
     as _i5;
 import 'package:mockito/mockito.dart' as _i1;
@@ -148,7 +147,7 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     String? payload,
-    _i9.DateTimeComponents? matchDateTimeComponents,
+    _i5.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#zonedSchedule, [], {
@@ -251,10 +250,10 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i10.AndroidFlutterLocalNotificationsPlugin {
+    implements _i9.AndroidFlutterLocalNotificationsPlugin {
   @override
   _i3.Future<bool> initialize({
-    required _i11.AndroidInitializationSettings? settings,
+    required _i10.AndroidInitializationSettings? settings,
     _i5.DidReceiveNotificationResponseCallback?
     onDidReceiveNotificationResponse,
     _i5.DidReceiveBackgroundNotificationResponseCallback?
@@ -324,10 +323,10 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required _i7.TZDateTime? scheduledDate,
-    _i12.AndroidNotificationDetails? notificationDetails,
-    required _i8.AndroidScheduleMode? scheduleMode,
     String? payload,
-    _i9.DateTimeComponents? matchDateTimeComponents,
+    _i5.DateTimeComponents? matchDateTimeComponents,
+    _i11.AndroidNotificationDetails? notificationDetails,
+    _i8.AndroidScheduleMode? scheduleMode = _i8.AndroidScheduleMode.exact,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#zonedSchedule, [], {
@@ -335,10 +334,10 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
               #title: title,
               #body: body,
               #scheduledDate: scheduledDate,
-              #notificationDetails: notificationDetails,
-              #scheduleMode: scheduleMode,
               #payload: payload,
               #matchDateTimeComponents: matchDateTimeComponents,
+              #notificationDetails: notificationDetails,
+              #scheduleMode: scheduleMode,
             }),
             returnValue: _i3.Future<void>.value(),
             returnValueForMissingStub: _i3.Future<void>.value(),
@@ -350,11 +349,11 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
     required int? id,
     String? title,
     String? body,
-    _i12.AndroidNotificationDetails? notificationDetails,
+    _i11.AndroidNotificationDetails? notificationDetails,
     String? payload,
-    _i13.AndroidServiceStartType? startType =
-        _i13.AndroidServiceStartType.startSticky,
-    Set<_i13.AndroidServiceForegroundType>? foregroundServiceTypes,
+    _i12.AndroidServiceStartType? startType =
+        _i12.AndroidServiceStartType.startSticky,
+    Set<_i12.AndroidServiceForegroundType>? foregroundServiceTypes,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#startForegroundService, [], {
@@ -385,7 +384,7 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
     required int? id,
     String? title,
     String? body,
-    _i12.AndroidNotificationDetails? notificationDetails,
+    _i11.AndroidNotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -407,7 +406,7 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required _i5.RepeatInterval? repeatInterval,
-    _i12.AndroidNotificationDetails? notificationDetails,
+    _i11.AndroidNotificationDetails? notificationDetails,
     String? payload,
     _i8.AndroidScheduleMode? scheduleMode = _i8.AndroidScheduleMode.exact,
   }) =>
@@ -432,7 +431,7 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required Duration? repeatDurationInterval,
-    _i12.AndroidNotificationDetails? notificationDetails,
+    _i11.AndroidNotificationDetails? notificationDetails,
     String? payload,
     _i8.AndroidScheduleMode? scheduleMode = _i8.AndroidScheduleMode.exact,
   }) =>
@@ -462,7 +461,7 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
 
   @override
   _i3.Future<void> createNotificationChannelGroup(
-    _i14.AndroidNotificationChannelGroup? notificationChannelGroup,
+    _i13.AndroidNotificationChannelGroup? notificationChannelGroup,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#createNotificationChannelGroup, [
@@ -486,7 +485,7 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
 
   @override
   _i3.Future<void> createNotificationChannel(
-    _i15.AndroidNotificationChannel? notificationChannel,
+    _i14.AndroidNotificationChannel? notificationChannel,
   ) =>
       (super.noSuchMethod(
             Invocation.method(#createNotificationChannel, [
@@ -509,30 +508,30 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
           as _i3.Future<void>);
 
   @override
-  _i3.Future<_i16.MessagingStyleInformation?>
+  _i3.Future<_i15.MessagingStyleInformation?>
   getActiveNotificationMessagingStyle({required int? id, String? tag}) =>
       (super.noSuchMethod(
             Invocation.method(#getActiveNotificationMessagingStyle, [], {
               #id: id,
               #tag: tag,
             }),
-            returnValue: _i3.Future<_i16.MessagingStyleInformation?>.value(),
+            returnValue: _i3.Future<_i15.MessagingStyleInformation?>.value(),
             returnValueForMissingStub:
-                _i3.Future<_i16.MessagingStyleInformation?>.value(),
+                _i3.Future<_i15.MessagingStyleInformation?>.value(),
           )
-          as _i3.Future<_i16.MessagingStyleInformation?>);
+          as _i3.Future<_i15.MessagingStyleInformation?>);
 
   @override
-  _i3.Future<List<_i15.AndroidNotificationChannel>?>
+  _i3.Future<List<_i14.AndroidNotificationChannel>?>
   getNotificationChannels() =>
       (super.noSuchMethod(
             Invocation.method(#getNotificationChannels, []),
             returnValue:
-                _i3.Future<List<_i15.AndroidNotificationChannel>?>.value(),
+                _i3.Future<List<_i14.AndroidNotificationChannel>?>.value(),
             returnValueForMissingStub:
-                _i3.Future<List<_i15.AndroidNotificationChannel>?>.value(),
+                _i3.Future<List<_i14.AndroidNotificationChannel>?>.value(),
           )
-          as _i3.Future<List<_i15.AndroidNotificationChannel>?>);
+          as _i3.Future<List<_i14.AndroidNotificationChannel>?>);
 
   @override
   _i3.Future<bool?> areNotificationsEnabled() =>
@@ -615,10 +614,10 @@ class MockAndroidFlutterLocalNotificationsPlugin extends _i1.Mock
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i10.IOSFlutterLocalNotificationsPlugin {
+    implements _i9.IOSFlutterLocalNotificationsPlugin {
   @override
   _i3.Future<bool?> initialize({
-    required _i17.DarwinInitializationSettings? settings,
+    required _i16.DarwinInitializationSettings? settings,
     _i5.DidReceiveNotificationResponseCallback?
     onDidReceiveNotificationResponse,
     _i5.DidReceiveBackgroundNotificationResponseCallback?
@@ -663,14 +662,14 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
           as _i3.Future<bool?>);
 
   @override
-  _i3.Future<_i18.NotificationsEnabledOptions?> checkPermissions() =>
+  _i3.Future<_i17.NotificationsEnabledOptions?> checkPermissions() =>
       (super.noSuchMethod(
             Invocation.method(#checkPermissions, []),
-            returnValue: _i3.Future<_i18.NotificationsEnabledOptions?>.value(),
+            returnValue: _i3.Future<_i17.NotificationsEnabledOptions?>.value(),
             returnValueForMissingStub:
-                _i3.Future<_i18.NotificationsEnabledOptions?>.value(),
+                _i3.Future<_i17.NotificationsEnabledOptions?>.value(),
           )
-          as _i3.Future<_i18.NotificationsEnabledOptions?>);
+          as _i3.Future<_i17.NotificationsEnabledOptions?>);
 
   @override
   _i3.Future<void> zonedSchedule({
@@ -678,9 +677,9 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required _i7.TZDateTime? scheduledDate,
-    _i19.DarwinNotificationDetails? notificationDetails,
     String? payload,
-    _i9.DateTimeComponents? matchDateTimeComponents,
+    _i5.DateTimeComponents? matchDateTimeComponents,
+    _i18.DarwinNotificationDetails? notificationDetails,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#zonedSchedule, [], {
@@ -688,9 +687,9 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
               #title: title,
               #body: body,
               #scheduledDate: scheduledDate,
-              #notificationDetails: notificationDetails,
               #payload: payload,
               #matchDateTimeComponents: matchDateTimeComponents,
+              #notificationDetails: notificationDetails,
             }),
             returnValue: _i3.Future<void>.value(),
             returnValueForMissingStub: _i3.Future<void>.value(),
@@ -702,7 +701,7 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
     required int? id,
     String? title,
     String? body,
-    _i19.DarwinNotificationDetails? notificationDetails,
+    _i18.DarwinNotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -724,7 +723,7 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required _i5.RepeatInterval? repeatInterval,
-    _i19.DarwinNotificationDetails? notificationDetails,
+    _i18.DarwinNotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -747,7 +746,7 @@ class MockIOSFlutterLocalNotificationsPlugin extends _i1.Mock
     String? title,
     String? body,
     required Duration? repeatDurationInterval,
-    _i19.DarwinNotificationDetails? notificationDetails,
+    _i18.DarwinNotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(

--- a/packages/core/notification_client/test/utils/mock_flutter_timezone.dart
+++ b/packages/core/notification_client/test/utils/mock_flutter_timezone.dart
@@ -11,7 +11,7 @@ void setupMockFlutterTimezone() {
         methodCallLog.add(methodCall);
         switch (methodCall.method) {
           case 'getLocalTimezone':
-            return 'UTC';
+            return 'Etc/UTC';
           default:
             return null;
         }

--- a/packages/features/exporter/pubspec.yaml
+++ b/packages/features/exporter/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.5
   pdf: ^3.12.0
-  printing: ^5.14.3
+  printing: ^5.15.0
   share_plus: ^12.0.1
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -349,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.13"
   drift:
     dependency: transitive
     description:
@@ -527,13 +527,14 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_gen_core:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_gen_core
-      sha256: b6bafbbd981da2f964eb45bcb8b8a7676a281084f8922c0c75de4cfbaa849311
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.12.0"
+      path: "packages/core"
+      ref: "3d5da4c853bae03c5559ca24039c9cdccfd44014"
+      resolved-ref: "3d5da4c853bae03c5559ca24039c9cdccfd44014"
+      url: "https://github.com/FlutterGen/flutter_gen.git"
+    source: git
+    version: "5.14.1"
   flutter_gen_runner:
     dependency: transitive
     description:
@@ -562,34 +563,42 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications
-      sha256: "2b50e938a275e1ad77352d6a25e25770f4130baa61eaf02de7a9a884680954ad"
+      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
       url: "https://pub.dev"
     source: hosted
-    version: "20.1.0"
+    version: "22.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: dce0116868cedd2cdf768af0365fc37ff1cbef7c02c4f51d0587482e625868d0
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "23de31678a48c084169d7ae95866df9de5c9d2a44be3e5915a2ff067aeeba899"
+      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "12.0.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: e97a1a3016512437d9c0b12fae7d1491c3c7b9aa7f03a69b974308840656b02a
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.1.1"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -599,10 +608,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_native_splash
-      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
+      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -777,10 +786,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.4"
+    version: "4.9.1"
   image_size_getter:
     dependency: transitive
     description:
@@ -913,10 +922,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: e3379a08af92a719a76d4cce9644c98dc87554e0fa3f2a93eb9a04bb295d4a03
+      sha256: b40731f34d3aacb199641a9b4955e52a866b0b0bc93ffc5c8ff21bffc6593134
       url: "https://pub.dev"
     source: hosted
-    version: "7.4.1"
+    version: "7.8.1"
   meta:
     dependency: transitive
     description:
@@ -1065,10 +1074,10 @@ packages:
     dependency: transitive
     description:
       name: pdf
-      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      sha256: "517df47af468734a23c8b513c0c6a8a62357403ab1b8ab7fad1606576a9dbdd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.12.0"
+    version: "3.13.0"
   pdf_widget_wrapper:
     dependency: transitive
     description:
@@ -1081,10 +1090,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.0.2"
   photo_manager:
     dependency: transitive
     description:
@@ -1137,10 +1146,10 @@ packages:
     dependency: transitive
     description:
       name: printing
-      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      sha256: f6cd14c768c1352dd37a958a3ee351aa9ce305b398218d3acd86389d5f7ecad1
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.3"
+    version: "5.15.0"
   process:
     dependency: transitive
     description:
@@ -1558,10 +1567,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   toastification:
     dependency: transitive
     description:
@@ -1670,10 +1679,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
+      sha256: "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.19"
+    version: "1.2.6"
   vector_math:
     dependency: transitive
     description:
@@ -1766,10 +1775,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:
@@ -1788,4 +1797,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,14 @@ workspace:
   - packages/features/scroll_calendar
   - packages/features/update_requester
 
+dependency_overrides:
+  # Pending flutter_gen_core release with xml 7 support (PR #764 merged 2026-06-09)
+  flutter_gen_core:
+    git:
+      url: https://github.com/FlutterGen/flutter_gen.git
+      path: packages/core
+      ref: 3d5da4c853bae03c5559ca24039c9cdccfd44014
+
 dev_dependencies:
   melos: ^7.4.1
 


### PR DESCRIPTION
closes #251

## 🙌 What's Done

### printing 5.14.3 → 5.15.0
- Update to the SPM-compatible version
- Remove printing-related entries from `Podfile.lock` / `project.pbxproj` since CocoaPods is no longer needed for printing

### flutter_local_notifications 20.1.0 → 22.0.1
- Bump `timezone` 0.10.1 → 0.11.0 (required by 22.0.1)
- Update test timezone mock from `UTC` to `Etc/UTC` (`UTC` location was removed in timezone 0.11.0)
- Regenerate mock files for updated API signatures

### flutter_gen_core dependency override
- printing 5.15.0 requires xml ^7.0.1, but flutter_gen_core 5.14.1 depends on xml ^6.0.0
- flutter_gen_core already has xml 7 support merged but not yet released
- Pin to commit `3d5da4c8` via `dependency_overrides`; revert to a normal pub dependency once released

## ✍️ What's Not Done

- Remove `flutter_gen_core` dependency override once a new version with xml 7 support is released on pub.dev

## 📝 Additional Notes

None

## 🖼️ Image Differences

None (dependency upgrade only, no UI changes)

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)