### PR TITLE
fix(android): align each module's Kotlin JVM target with its Java target

### DIFF
--- a/packages/app/android/build.gradle.kts
+++ b/packages/app/android/build.gradle.kts
@@ -12,6 +12,44 @@ subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 }
+
+// Align each module's Kotlin JVM target with the Java target that module
+// already declares.
+//
+// Plugins that only configure their Kotlin jvmTarget when
+// `android.builtInKotlin=true` (photo_manager 3.10.0, for example) leave it
+// unset for this app, because the Flutter migrator pinned that flag to false in
+// gradle.properties. Kotlin then falls back to the JDK running Gradle, so
+// building with a JDK newer than the module's Java target fails with
+// "Inconsistent JVM-target compatibility detected for tasks
+// 'compileDebugJavaWithJavac' and 'compileDebugKotlin'".
+//
+// Targets are copied per module rather than forced to a single value, because
+// plugins do not agree on one (:app and photo_manager use 17, app_settings
+// uses 11).
+//
+// The Java target is read through a provider: AGP has not finalized
+// `compileOptions` while the project is still being evaluated, so the value can
+// only be queried once the Kotlin task is realized.
+subprojects {
+    val module = this
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(
+                module.provider {
+                    @Suppress("DEPRECATION")
+                    val androidExtension =
+                        module.extensions.findByName("android")
+                            as? com.android.build.gradle.BaseExtension
+                    val javaTarget = androidExtension?.compileOptions?.targetCompatibility
+                        ?: JavaVersion.VERSION_17
+                    org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(javaTarget.toString())
+                },
+            )
+        }
+    }
+}
+
 subprojects {
     project.evaluationDependsOn(":app")
 }


### PR DESCRIPTION
## 🙌 What's Done

- Align each Android module's Kotlin JVM target with the Java target that module already declares, in `packages/app/android/build.gradle.kts`
- Fixes the local Android build failure introduced by #264 (photo_manager 3.8.3 → 3.10.0):

  ```
  Execution failed for task ':photo_manager:compileDebugKotlin'.
  > Inconsistent JVM-target compatibility detected for tasks
    'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21).
  ```

## ✍️ What's Not Done

- An Android build job in PR CI. `flutter-app-code-check.yml` runs analyze / format / test only, and the two `upload-*-android-app.yaml` workflows build on `pull_request: types: [closed]` — after merge. #264 therefore passed CI because the Android build never ran on it, not because CI happened to use a compatible JDK. Adding a debug build to PR CI is the change that would actually catch this class of regression, at the cost of a few minutes per run.
- Built-in Kotlin migration (the KGP warning), still blocked on the plugin ecosystem as described in #250.

## 📝 Additional Notes

### Why photo_manager 3.10.0 breaks the build

3.8.3 set the Kotlin JVM target unconditionally:

```groovy
kotlinOptions { jvmTarget = '17' }
```

3.10.0 only sets it when Built-in Kotlin is active:

```groovy
if (useBuiltInKotlin) {
    kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }
}
```

`android/gradle.properties` pins `android.builtInKotlin=false` (added by the Flutter migrator in #250), so the branch never runs and Kotlin falls back to the JDK running Gradle. The module still declares Java 17 in `compileOptions`, so any JDK newer than 17 — JDK 21 locally — produces the mismatch.

### Why targets are copied per module instead of forced to 17

Forcing every module to 17 swaps the failure to the other side: `app_settings` declares Java 11, so its Kotlin task then overshoots its own Java target and fails with the same error inverted (`'compileDebugJavaWithJavac' (11) and 'compileDebugKotlin' (17)`). Copying each module's own declared Java target keeps every plugin exactly as its author configured it, and covers future plugins that make the same omission.

### Why the Java target is read through a provider

Reading `android.compileOptions.targetCompatibility` inside `afterEvaluate` fails with `targetCompatibility is not yet finalized` — AGP finalizes the DSL after project evaluation. Wrapping the read in a `provider {}` defers it until the Kotlin task is realized, by which point the value is final. `evaluationDependsOn(":app")` in the existing block also evaluates `:app` eagerly, which rules out `afterEvaluate` for that module entirely.

### Verification

- `fvm flutter clean` + `fvm flutter build apk --debug --dart-define-from-file=dart_defines/dev.env` → ✓ Built (clean build from scratch)
- `fvm flutter build appbundle --dart-define-from-file=dart_defines/prod.env` → ✓ Built (73.8MB, same path as the release workflow)
- `fvm dart analyze` → No issues found!

## 🖼️ Image Differences

None (Gradle build configuration only, no UI changes)

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)
